### PR TITLE
typo fix

### DIFF
--- a/14-317/info.json
+++ b/14-317/info.json
@@ -4,8 +4,7 @@
         "An C. Tran",
         "Jens Dietrich",
         "Hans W. Guesgen",
-        "Stephen Marsl",
-        ""
+        "Stephen Marsland"
     ],
     "id": "14-317",
     "issue": 64,

--- a/15-484/15-484.bib
+++ b/15-484/15-484.bib
@@ -1,5 +1,5 @@
 @article{JMLR:v18:15-484,
-  author  = {Fr{\'e}d{\'e}ric Chazal and Brittany Fasy and Fabrizio Lecci and Bertrand Michel and Alessandro Rinaldo and Larry Wasserman},
+  author  = {Frédéric Chazal and Brittany Fasy and Fabrizio Lecci and Bertrand Michel and Alessandro Rinaldo and Larry Wasserman},
   title   = {Robust Topological Inference: Distance To a Measure and Kernel Distance},
   journal = {Journal of Machine Learning Research},
   year    = {2018},

--- a/15-484/info.json
+++ b/15-484/info.json
@@ -1,13 +1,11 @@
 {
     "abstract": "Let $P$ be a distribution with support $S$. The salient features of $S$ can be quantified with persistent homology, which summarizes topological features of the sublevel sets of the distance function (the distance of any point $x$ to $S$). Given a sample from $P$ we can infer the persistent homology using an empirical version of the distance function. However, the empirical distance function is highly non-robust to noise and outliers. Even one outlier is deadly. The distance-to-a-measure (DTM), introduced by \\cite{chazal2011geometric}, and the kernel distance, introduced by \\cite{phillips2014goemetric}, are smooth functions that provide useful topological information but are robust to noise and outliers. \\cite{massart2014} derived concentration bounds for DTM. Building on these results, we derive limiting distributions and confidence sets, and we propose a method for choosing tuning parameters.",
     "authors": [
-        "Fr{\\'e}d{\\'e}ric Chazal",
+        "Frédéric Chazal",
         "Brittany Fasy",
         "Fabrizio Lecci",
-        "Bertr",
-        "Michel",
-        "Aless",
-        "ro Rinaldo",
+        "Bertrand Michel",
+        "Alessandro Rinaldo",
         "Larry Wasserman"
     ],
     "id": "15-484",

--- a/15-486/info.json
+++ b/15-486/info.json
@@ -1,8 +1,7 @@
 {
     "abstract": "We present a novel analysis of the dynamics of tensor power iterations in the overcomplete regime where the tensor CP rank is larger than the input dimension. Finding the CP decomposition of an overcomplete tensor is NP-hard in general. We consider the case where the tensor components are randomly drawn, and show that the simple power iteration recovers the components with bounded error under mild initialization conditions. We apply our analysis to unsupervised learning of latent variable models, such as multi-view mixture models and spherical Gaussian mixtures. Given the third order moment tensor, we learn the parameters using tensor power iterations. We prove it can correctly learn the model parameters when the number of hidden components $k$ is much larger than the data dimension $d$, up to $k = o(d^{1.5})$. We initialize the power iterations with data samples and prove its success under mild conditions on the signal-to-noise ratio of the samples. Our analysis significantly expands the class of latent variable models where spectral methods are applicable. Our analysis also deals with noise in the input tensor leading to sample complexity result in the application to learning latent variable models.",
     "authors": [
-        "Animashree An",
-        "kumar",
+        "Animashree Anandkumar",
         "Rong Ge",
         "Majid Janzamin"
     ],

--- a/16-011/16-011.bib
+++ b/16-011/16-011.bib
@@ -1,5 +1,5 @@
 @article{JMLR:v18:16-011,
-  author  = {Bharath Sriperumbudur and Kenji Fukumizu and Arthur Gretton and Aapo Hyv\"{a}rinen and Revant Kumar},
+  author  = {Bharath Sriperumbudur and Kenji Fukumizu and Arthur Gretton and Aapo Hyvärinen and Revant Kumar},
   title   = {Density Estimation in Infinite Dimensional Exponential Families},
   journal = {Journal of Machine Learning Research},
   year    = {2017},

--- a/16-011/info.json
+++ b/16-011/info.json
@@ -4,7 +4,7 @@
         "Bharath Sriperumbudur",
         "Kenji Fukumizu",
         "Arthur Gretton",
-        "Aapo Hyv\\\"{a}rinen",
+        "Aapo Hyvärinen",
         "Revant Kumar"
     ],
     "id": "16-011",

--- a/16-017/info.json
+++ b/16-017/info.json
@@ -3,8 +3,7 @@
     "authors": [
         "Stanislas Lauly",
         "Yin Zheng",
-        "Alex",
-        "re Allauzen",
+        "Alexandre Allauzen",
         "Hugo Larochelle"
     ],
     "id": "16-017",

--- a/16-087/info.json
+++ b/16-087/info.json
@@ -4,8 +4,7 @@
         "Simone Filice",
         "Giuseppe Castellucci",
         "Giovanni Da San Martino",
-        "Aless",
-        "ro Moschitti",
+        "Alessandro Moschitti",
         "Danilo Croce",
         "Roberto Basili"
     ],

--- a/16-212/16-212.bib
+++ b/16-212/16-212.bib
@@ -1,5 +1,5 @@
 @article{JMLR:v18:16-212,
-  author  = {Weiwei Liu and Ivor W. Tsang and Klaus-Robert M\"{u}ller},
+  author  = {Weiwei Liu and Ivor W. Tsang and Klaus-Robert Müller},
   title   = {An Easy-to-hard Learning Paradigm for Multiple Classes and Multiple Labels},
   journal = {Journal of Machine Learning Research},
   year    = {2017},

--- a/16-212/info.json
+++ b/16-212/info.json
@@ -3,7 +3,7 @@
     "authors": [
         "Weiwei Liu",
         "Ivor W. Tsang",
-        "Klaus-Robert M\\\"{u}ller"
+        "Klaus-Robert Müller"
     ],
     "id": "16-212",
     "issue": 94,

--- a/16-232/info.json
+++ b/16-232/info.json
@@ -2,8 +2,7 @@
     "abstract": "Information about intrinsic dimension is crucial to perform dimensionality reduction, compress information, design efficient algorithms, and do statistical adaptation. In this paper we propose an estimator for the intrinsic dimension of a data set. The estimator is based on binary neighbourhood information about the observations in the form of two adjacency matrices, and does not require any explicit distance information. The underlying graph is modelled according to a subset of a specific random connection model, sometimes referred to as the Poisson blob model. Computationally the estimator scales like $n\\log n$, and we specify its asymptotic distribution and rate of convergence. A simulation study on both real and simulated data shows that our approach compares favourably with some competing methods from the literature, including approaches that rely on distance information.",
     "authors": [
         "Paulo Serra",
-        "Michel M",
-        "jes"
+        "Michel Mandjes"
     ],
     "id": "16-232",
     "issue": 138,

--- a/16-326/16-326.bib
+++ b/16-326/16-326.bib
@@ -1,5 +1,5 @@
 @article{JMLR:v18:16-326,
-  author  = {David Mart\'{i}nez and Guillem Aleny\`{a} and Tony Ribeiro and Katsumi Inoue and Carme Torras},
+  author  = {David Martínez and Guillem Alenyà and Tony Ribeiro and Katsumi Inoue and Carme Torras},
   title   = {Relational Reinforcement Learning for Planning with Exogenous Effects},
   journal = {Journal of Machine Learning Research},
   year    = {2017},

--- a/16-326/info.json
+++ b/16-326/info.json
@@ -1,8 +1,8 @@
 {
     "abstract": "Probabilistic planners have improved recently to the point that they can solve difficult tasks with complex and expressive models. In contrast, learners cannot tackle yet the expressive models that planners do, which forces complex models to be mostly handcrafted. We propose a new learning approach that can learn relational probabilistic models with both action effects and exogenous effects. The proposed learning approach combines a multi-valued variant of inductive logic programming for the generation of candidate models, with an optimization method to select the best set of planning operators to model a problem. We also show how to combine this learner with reinforcement learning algorithms to solve complete problems. Finally, experimental validation is provided that shows improvements over previous work in both simulation and a robotic task. The robotic task involves a dynamic scenario with several agents where a manipulator robot has to clear the tableware on a table. We show that the exogenous effects learned by our approach allowed the robot to clear the table in a more efficient way.",
     "authors": [
-        "David Mart\\'{i}nez",
-        "Guillem Aleny\\`{a}",
+        "David Martínez",
+        "Guillem Alenyà",
         "Tony Ribeiro",
         "Katsumi Inoue",
         "Carme Torras"

--- a/16-460/info.json
+++ b/16-460/info.json
@@ -4,8 +4,7 @@
         "Ziyuan Gao",
         "Christoph Ries",
         "Hans U. Simon",
-        "S",
-        "ra Zilles"
+        "Sandra Zilles"
     ],
     "id": "16-460",
     "issue": 31,

--- a/16-497/info.json
+++ b/16-497/info.json
@@ -1,8 +1,7 @@
 {
     "abstract": "Our work in this paper is inspired by a statistical observation that is both elementary and broadly relevant to network analysis in practice---that the uncertainty in approximating some true graph $G=(V,E)$ by some estimated graph $\\hat{G}=(V,\\hat{E})$ manifests as errors in our knowledge of the presence/absence of edges between vertex pairs, which must necessarily propagate to any estimates of network summaries $\\eta(G)$ we seek. Motivated by the common practice of using plug-in estimates $\\eta(\\hat{G})$ as proxies for $\\eta(G)$, our focus is on the problem of characterizing the distribution of the discrepancy $D=\\eta(\\hat{G}) - \\eta(G)$, in the case where $\\eta(\\cdot)$ is a subgraph count. Specifically, we study the fundamental case where the statistic of interest is $|E|$, the number of edges in $G$. Our primary contribution in this paper is to show that in the empirically relevant setting of large graphs with low-rate measurement errors, the distribution of $D_E=|\\hat{E}| - |E|$ is well-characterized by a Skellam distribution, when the errors are independent or weakly dependent. Under an assumption of independent errors, we are able to further show conditions under which this characterization is strictly better than that of an appropriate normal distribution. These results derive from our formulation of a general result, quantifying the accuracy with which the difference of two sums of dependent Bernoulli random variables may be approximated by the difference of two independent Poisson random variables, i.e., by a Skellam distribution. This general result is developed through the use of Stein's method, and may be of some general interest. We finish with a discussion of possible extension of our work to subgraph counts $\\eta(G)$ of higher order.",
     "authors": [
-        "Prakash Balach",
-        "ran",
+        "Prakash Balachandran",
         "Eric D. Kolaczyk",
         "Weston D. Viles"
     ],

--- a/16-537/16-537.bib
+++ b/16-537/16-537.bib
@@ -1,5 +1,5 @@
 @article{JMLR:v18:16-537,
-  author  = {Alexander G. de G. Matthews and Mark van der Wilk and Tom Nickson and Keisuke Fujii and Alexis Boukouvalas and Pablo Le{{\'o}}n-Villagr{{\'a}} and Zoubin Ghahramani and James Hensman},
+  author  = {Alexander G. de G. Matthews and Mark van der Wilk and Tom Nickson and Keisuke Fujii and Alexis Boukouvalas and Pablo León-Villagrá and Zoubin Ghahramani and James Hensman},
   title   = {GPflow: A Gaussian Process Library using TensorFlow},
   journal = {Journal of Machine Learning Research},
   year    = {2017},

--- a/16-537/info.json
+++ b/16-537/info.json
@@ -6,7 +6,7 @@
         "Tom Nickson",
         "Keisuke Fujii",
         "Alexis Boukouvalas",
-        "Pablo Le{\\'o}n-Villagr{\\'a}",
+        "Pablo León-Villagrá",
         "Zoubin Ghahramani",
         "James Hensman"
     ],

--- a/16-577/info.json
+++ b/16-577/info.json
@@ -3,8 +3,7 @@
     "authors": [
         "Eugene Ndiaye",
         "Olivier Fercoq",
-        "Alex",
-        "re Gramfort",
+        "Alexandre Gramfort",
         "Joseph Salmon"
     ],
     "id": "16-577",

--- a/17-032/info.json
+++ b/17-032/info.json
@@ -3,8 +3,7 @@
     "authors": [
         "Ilya Tolstikhin",
         "Bharath K. Sriperumbudur",
-        "Krikamol Mu",
-        "et"
+        "Krikamol Muandet"
     ],
     "id": "17-032",
     "issue": 86,

--- a/17-214/info.json
+++ b/17-214/info.json
@@ -1,8 +1,7 @@
 {
     "abstract": "Stochastic Gradient Descent with a constant learning rate (constant SGD) simulates a Markov chain with a stationary distribution. With this perspective, we derive several new results. (1) We show that constant SGD can be used as an approximate Bayesian posterior inference algorithm. Specifically, we show how to adjust the tuning parameters of constant SGD to best match the stationary distribution to a posterior, minimizing the Kullback-Leibler divergence between these two distributions. (2) We demonstrate that constant SGD gives rise to a new variational EM algorithm that optimizes hyperparameters in complex probabilistic models. (3) We also show how to tune SGD with momentum for approximate sampling. (4) We analyze stochastic-gradient MCMC algorithms. For Stochastic- Gradient Langevin Dynamics and Stochastic-Gradient Fisher Scoring, we quantify the approximation errors due to finite learning rates. Finally (5), we use the stochastic process perspective to give a short proof of why Polyak averaging is optimal. Based on this idea, we propose a scalable approximate MCMC algorithm, the Averaged Stochastic Gradient Sampler.",
     "authors": [
-        "Stephan M",
-        "t",
+        "Stephan Mandt",
         "Matthew D. Hoffman",
         "David M. Blei"
     ],

--- a/17-406/17-406.bib
+++ b/17-406/17-406.bib
@@ -1,5 +1,5 @@
 @article{JMLR:v18:17-406,
-  author  = {Michael Freitag and Shahin Amiriparian and Sergey Pugachevskiy and Nicholas Cummins and Bj\"{o}rn Schuller},
+  author  = {Michael Freitag and Shahin Amiriparian and Sergey Pugachevskiy and Nicholas Cummins and Björn Schuller},
   title   = {auDeep: Unsupervised Learning of Representations from Audio with Deep Recurrent Neural Networks},
   journal = {Journal of Machine Learning Research},
   year    = {2018},

--- a/17-406/info.json
+++ b/17-406/info.json
@@ -5,7 +5,7 @@
         "Shahin Amiriparian",
         "Sergey Pugachevskiy",
         "Nicholas Cummins",
-        "Bj\\\"{o}rn Schuller"
+        "Björn Schuller"
     ],
     "id": "17-406",
     "issue": 173,


### PR DESCRIPTION
1. Author name accent fix
2. Author name typo fix (accidently splited during parsing author name list)